### PR TITLE
Fix: Correct docs.json navigation structure for Mintlify

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8,44 +8,51 @@
     "dark": "#15803D"
   },
   "favicon": "/favicon.svg",
-  "navigation": [
-    {
-      "group": "Getting Started",
-      "pages": [
-        "index",
-        "getting-started/installation-setup"
-      ]
-    },
-    {
-      "group": "API Reference",
-      "pages": [
-        "api-reference/assign-endpoint",
-        "api-reference/log-endpoint"
-      ]
-    },
-    {
-      "group": "Concepts",
-      "pages": [
-        "concepts/experiments-variants",
-        "concepts/assignment-logging",
-        "concepts/authentication"
-      ]
-    },
-    {
-      "group": "Developer Guide",
-      "pages": [
-        "developer-guide/local-development",
-        "developer-guide/schema-db",
-        "developer-guide/sdk-integration"
-      ]
-    },
-    {
-      "group": "Roadmap",
-      "pages": [
-        "roadmap"
-      ]
-    }
-  ],
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Documentation",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "index",
+              "getting-started/installation-setup"
+            ]
+          },
+          {
+            "group": "API Reference",
+            "pages": [
+              "api-reference/assign-endpoint",
+              "api-reference/log-endpoint"
+            ]
+          },
+          {
+            "group": "Concepts",
+            "pages": [
+              "concepts/experiments-variants",
+              "concepts/assignment-logging",
+              "concepts/authentication"
+            ]
+          },
+          {
+            "group": "Developer Guide",
+            "pages": [
+              "developer-guide/local-development",
+              "developer-guide/schema-db",
+              "developer-guide/sdk-integration"
+            ]
+          },
+          {
+            "group": "Roadmap",
+            "pages": [
+              "roadmap"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "logo": {
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg"


### PR DESCRIPTION
This commit corrects the `docs.json` navigation structure to align with Mintlify's expected format. The previous array-based navigation was causing deployment errors.

The navigation groups are now nested under a `tabs` array, with a single tab named "Documentation" containing all the defined page groups.

This change ensures that the `docs.json` is valid and allows the Mintlify deployment to proceed correctly with all the previously created documentation content.